### PR TITLE
removed aliases, just using paths

### DIFF
--- a/app/javascript/components/App.js
+++ b/app/javascript/components/App.js
@@ -18,9 +18,7 @@ class App extends Component {
 
   getJobs = async () => {
     const loggedIn = this.props.logged_in
-    const url = loggedIn
-      ? this.props.user_jobs_route
-      : this.props.sample_jobs_route
+    const url = loggedIn ? "/jobs" : "/sample_jobs"
     const response = await fetch(url)
     const result = await response.json()
     this.setState({ jobs: result })

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,8 +3,6 @@
   current_user: current_user,
   new_user_route: new_user_registration_path,
   sign_in_route: new_user_session_path,
-  sample_jobs_route: sample_jobs_path,
-  user_jobs_route: jobs_path,
   sign_out_route: destroy_user_session_path
 } 
 %>


### PR DESCRIPTION
Moved away from using aliases. Originally thought it'd save time if I needed to refactor things on the backend. In theory, the pathname passed to App.js would stay the same no matter what I changed it to in the view. In practice, that's not gonna happen, and if it did I'd still have to rename the pathnames passed into App.js to something more generic.

Switched them over to the bare paths.